### PR TITLE
Add hack for granting access to Calendar

### DIFF
--- a/JPSimulatorHacks/JPSimulatorHacks.m
+++ b/JPSimulatorHacks/JPSimulatorHacks.m
@@ -31,7 +31,9 @@
 @implementation JPSimulatorHacks
 
 static NSString * const JPSimulatorHacksServiceAddressBook = @"kTCCServiceAddressBook";
-static NSString * const JPSimulatorHacksServicePhotos = @"kTCCServicePhotos";
+static NSString * const JPSimulatorHacksServicePhotos      = @"kTCCServicePhotos";
+static NSString * const JPSimulatorHacksServiceCalendar    = @"kTCCServiceCalendar";
+
 static NSTimeInterval JPSimulatorHacksTimeout = 15.0f;
 
 #pragma mark - Public
@@ -95,6 +97,20 @@ static NSTimeInterval JPSimulatorHacksTimeout = 15.0f;
 + (BOOL)grantAccessToPhotosForBundleIdentifier:(NSString *)bundleIdentifier
 {
     return [self changeAccessToService:JPSimulatorHacksServicePhotos
+                      bundleIdentifier:bundleIdentifier
+                               allowed:YES];
+}
+
++ (BOOL)grantAccessToCalendar
+{
+    return [self changeAccessToService:JPSimulatorHacksServiceCalendar
+                      bundleIdentifier:[NSBundle mainBundle].bundleIdentifier
+                               allowed:YES];
+}
+
++ (BOOL)grantAccessToCalendarForBundleIdentifier:(NSString *)bundleIdentifier
+{
+    return [self changeAccessToService:JPSimulatorHacksServiceCalendar
                       bundleIdentifier:bundleIdentifier
                                allowed:YES];
 }

--- a/JPSimulatorHacksSample.xcodeproj/project.pbxproj
+++ b/JPSimulatorHacksSample.xcodeproj/project.pbxproj
@@ -1,1097 +1,521 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>archiveVersion</key>
-	<string>1</string>
-	<key>classes</key>
-	<dict/>
-	<key>objectVersion</key>
-	<string>46</string>
-	<key>objects</key>
-	<dict>
-		<key>3DCFE79F67F8DBC0305663F4</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-JPSimulatorHacksSampleTests.release.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Pods-JPSimulatorHacksSampleTests.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3EC4F227193F9087005C8B43</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>3EC4F232193F9087005C8B43</string>
-				<string>3EF96CF1193F914500E117DC</string>
-				<string>3EC4F239193F9087005C8B43</string>
-				<string>3EC4F252193F9087005C8B43</string>
-				<string>3EC4F231193F9087005C8B43</string>
-				<string>A7B164568502C22791AA0ADA</string>
-				<string>3DCFE79F67F8DBC0305663F4</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3EC4F228193F9087005C8B43</key>
-		<dict>
-			<key>attributes</key>
-			<dict>
-				<key>CLASSPREFIX</key>
-				<string>JP</string>
-				<key>LastUpgradeCheck</key>
-				<string>0510</string>
-				<key>TargetAttributes</key>
-				<dict>
-					<key>3EC4F24A193F9087005C8B43</key>
-					<dict>
-						<key>TestTargetID</key>
-						<string>3EC4F22F193F9087005C8B43</string>
-					</dict>
-				</dict>
-			</dict>
-			<key>buildConfigurationList</key>
-			<string>3EC4F22B193F9087005C8B43</string>
-			<key>compatibilityVersion</key>
-			<string>Xcode 3.2</string>
-			<key>developmentRegion</key>
-			<string>English</string>
-			<key>hasScannedForEncodings</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXProject</string>
-			<key>knownRegions</key>
-			<array>
-				<string>en</string>
-			</array>
-			<key>mainGroup</key>
-			<string>3EC4F227193F9087005C8B43</string>
-			<key>productRefGroup</key>
-			<string>3EC4F231193F9087005C8B43</string>
-			<key>projectDirPath</key>
-			<string></string>
-			<key>projectReferences</key>
-			<array/>
-			<key>projectRoot</key>
-			<string></string>
-			<key>targets</key>
-			<array>
-				<string>3EC4F22F193F9087005C8B43</string>
-				<string>3EC4F24A193F9087005C8B43</string>
-			</array>
-		</dict>
-		<key>3EC4F22B193F9087005C8B43</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>3EC4F25A193F9087005C8B43</string>
-				<string>3EC4F25B193F9087005C8B43</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>3EC4F22C193F9087005C8B43</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>3EC4F244193F9087005C8B43</string>
-				<string>3EC4F240193F9087005C8B43</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>3EC4F22D193F9087005C8B43</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>3EC4F236193F9087005C8B43</string>
-				<string>3EC4F238193F9087005C8B43</string>
-				<string>3EC4F234193F9087005C8B43</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>3EC4F22E193F9087005C8B43</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>3EC4F23E193F9087005C8B43</string>
-				<string>3EC4F246193F9087005C8B43</string>
-				<string>679B02351965D14D00600C91</string>
-			</array>
-			<key>isa</key>
-			<string>PBXResourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>3EC4F22F193F9087005C8B43</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>3EC4F25C193F9087005C8B43</string>
-			<key>buildPhases</key>
-			<array>
-				<string>3EC4F22C193F9087005C8B43</string>
-				<string>3EC4F22D193F9087005C8B43</string>
-				<string>3EC4F22E193F9087005C8B43</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>JPSimulatorHacksSample</string>
-			<key>productName</key>
-			<string>JPSimulatorHacksSample</string>
-			<key>productReference</key>
-			<string>3EC4F230193F9087005C8B43</string>
-			<key>productType</key>
-			<string>com.apple.product-type.application</string>
-		</dict>
-		<key>3EC4F230193F9087005C8B43</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.application</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>JPSimulatorHacksSample.app</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>3EC4F231193F9087005C8B43</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>3EC4F230193F9087005C8B43</string>
-				<string>3EC4F24B193F9087005C8B43</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Products</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3EC4F232193F9087005C8B43</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>3EC4F233193F9087005C8B43</string>
-				<string>3EC4F235193F9087005C8B43</string>
-				<string>3EC4F237193F9087005C8B43</string>
-				<string>3EC4F24C193F9087005C8B43</string>
-				<string>49F39C16C71D470F95035BC9</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Frameworks</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3EC4F233193F9087005C8B43</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Foundation.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/Foundation.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>3EC4F234193F9087005C8B43</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3EC4F233193F9087005C8B43</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3EC4F235193F9087005C8B43</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CoreGraphics.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/CoreGraphics.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>3EC4F236193F9087005C8B43</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3EC4F235193F9087005C8B43</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3EC4F237193F9087005C8B43</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>UIKit.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/UIKit.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>3EC4F238193F9087005C8B43</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3EC4F237193F9087005C8B43</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3EC4F239193F9087005C8B43</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>3EC4F245193F9087005C8B43</string>
-				<string>3EC4F242193F9087005C8B43</string>
-				<string>3EC4F243193F9087005C8B43</string>
-				<string>679B02341965D14D00600C91</string>
-				<string>3EC4F23A193F9087005C8B43</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>JPSimulatorHacksSample</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3EC4F23A193F9087005C8B43</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>3EC4F23B193F9087005C8B43</string>
-				<string>3EC4F23C193F9087005C8B43</string>
-				<string>3EC4F23F193F9087005C8B43</string>
-				<string>3EC4F241193F9087005C8B43</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Supporting Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3EC4F23B193F9087005C8B43</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>JPSimulatorHacksSample-Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3EC4F23C193F9087005C8B43</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>3EC4F23D193F9087005C8B43</string>
-			</array>
-			<key>isa</key>
-			<string>PBXVariantGroup</string>
-			<key>name</key>
-			<string>InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3EC4F23D193F9087005C8B43</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.strings</string>
-			<key>name</key>
-			<string>en</string>
-			<key>path</key>
-			<string>en.lproj/InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3EC4F23E193F9087005C8B43</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3EC4F23C193F9087005C8B43</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3EC4F23F193F9087005C8B43</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>main.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3EC4F240193F9087005C8B43</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3EC4F23F193F9087005C8B43</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3EC4F241193F9087005C8B43</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>JPSimulatorHacksSample-Prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3EC4F242193F9087005C8B43</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>JPAppDelegate.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3EC4F243193F9087005C8B43</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>JPAppDelegate.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3EC4F244193F9087005C8B43</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3EC4F243193F9087005C8B43</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3EC4F245193F9087005C8B43</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>folder.assetcatalog</string>
-			<key>path</key>
-			<string>Images.xcassets</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3EC4F246193F9087005C8B43</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3EC4F245193F9087005C8B43</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3EC4F247193F9087005C8B43</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>3EC4F259193F9087005C8B43</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>3EC4F248193F9087005C8B43</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>3EC4F24D193F9087005C8B43</string>
-				<string>3EC4F24F193F9087005C8B43</string>
-				<string>3EC4F24E193F9087005C8B43</string>
-				<string>63BE4141C44748CCB995A770</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>3EC4F249193F9087005C8B43</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>3EC4F257193F9087005C8B43</string>
-			</array>
-			<key>isa</key>
-			<string>PBXResourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>3EC4F24A193F9087005C8B43</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>3EC4F25F193F9087005C8B43</string>
-			<key>buildPhases</key>
-			<array>
-				<string>5334BE86380A408DBF393030</string>
-				<string>3EC4F247193F9087005C8B43</string>
-				<string>3EC4F248193F9087005C8B43</string>
-				<string>3EC4F249193F9087005C8B43</string>
-				<string>6052FE846C274F77BB137DD5</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>3EC4F251193F9087005C8B43</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>JPSimulatorHacksSampleTests</string>
-			<key>productName</key>
-			<string>JPSimulatorHacksSampleTests</string>
-			<key>productReference</key>
-			<string>3EC4F24B193F9087005C8B43</string>
-			<key>productType</key>
-			<string>com.apple.product-type.bundle.unit-test</string>
-		</dict>
-		<key>3EC4F24B193F9087005C8B43</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.cfbundle</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>JPSimulatorHacksSampleTests.xctest</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>3EC4F24C193F9087005C8B43</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>XCTest.framework</string>
-			<key>path</key>
-			<string>Library/Frameworks/XCTest.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>3EC4F24D193F9087005C8B43</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3EC4F24C193F9087005C8B43</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3EC4F24E193F9087005C8B43</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3EC4F233193F9087005C8B43</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3EC4F24F193F9087005C8B43</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3EC4F237193F9087005C8B43</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3EC4F250193F9087005C8B43</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>3EC4F228193F9087005C8B43</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>3EC4F22F193F9087005C8B43</string>
-			<key>remoteInfo</key>
-			<string>JPSimulatorHacksSample</string>
-		</dict>
-		<key>3EC4F251193F9087005C8B43</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>target</key>
-			<string>3EC4F22F193F9087005C8B43</string>
-			<key>targetProxy</key>
-			<string>3EC4F250193F9087005C8B43</string>
-		</dict>
-		<key>3EC4F252193F9087005C8B43</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>3EC4F258193F9087005C8B43</string>
-				<string>3EC4F253193F9087005C8B43</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>JPSimulatorHacksSampleTests</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3EC4F253193F9087005C8B43</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>3EC4F254193F9087005C8B43</string>
-				<string>3EC4F255193F9087005C8B43</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Supporting Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3EC4F254193F9087005C8B43</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>JPSimulatorHacksSampleTests-Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3EC4F255193F9087005C8B43</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>3EC4F256193F9087005C8B43</string>
-			</array>
-			<key>isa</key>
-			<string>PBXVariantGroup</string>
-			<key>name</key>
-			<string>InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3EC4F256193F9087005C8B43</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.strings</string>
-			<key>name</key>
-			<string>en</string>
-			<key>path</key>
-			<string>en.lproj/InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3EC4F257193F9087005C8B43</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3EC4F255193F9087005C8B43</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3EC4F258193F9087005C8B43</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>JPSimulatorHacksSampleTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3EC4F259193F9087005C8B43</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3EC4F258193F9087005C8B43</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3EC4F25A193F9087005C8B43</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES_AGGRESSIVE</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.1</string>
-				<key>ONLY_ACTIVE_ARCH</key>
-				<string>YES</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>3EC4F25B193F9087005C8B43</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>ENABLE_NS_ASSERTIONS</key>
-				<string>NO</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES_AGGRESSIVE</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.1</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>3EC4F25C193F9087005C8B43</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>3EC4F25D193F9087005C8B43</string>
-				<string>3EC4F25E193F9087005C8B43</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>3EC4F25D193F9087005C8B43</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ASSETCATALOG_COMPILER_APPICON_NAME</key>
-				<string>AppIcon</string>
-				<key>ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME</key>
-				<string>LaunchImage</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>JPSimulatorHacksSample/JPSimulatorHacksSample-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>JPSimulatorHacksSample/JPSimulatorHacksSample-Info.plist</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>app</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>3EC4F25E193F9087005C8B43</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ASSETCATALOG_COMPILER_APPICON_NAME</key>
-				<string>AppIcon</string>
-				<key>ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME</key>
-				<string>LaunchImage</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>JPSimulatorHacksSample/JPSimulatorHacksSample-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>JPSimulatorHacksSample/JPSimulatorHacksSample-Info.plist</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>app</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>3EC4F25F193F9087005C8B43</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>3EC4F260193F9087005C8B43</string>
-				<string>3EC4F261193F9087005C8B43</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>3EC4F260193F9087005C8B43</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>A7B164568502C22791AA0ADA</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>BUNDLE_LOADER</key>
-				<string>$(BUILT_PRODUCTS_DIR)/JPSimulatorHacksSample.app/JPSimulatorHacksSample</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(SDKROOT)/Developer/Library/Frameworks</string>
-					<string>$(inherited)</string>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-				</array>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>JPSimulatorHacksSample/JPSimulatorHacksSample-Prefix.pch</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>INFOPLIST_FILE</key>
-				<string>JPSimulatorHacksSampleTests/JPSimulatorHacksSampleTests-Info.plist</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>TEST_HOST</key>
-				<string>$(BUNDLE_LOADER)</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>xctest</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>3EC4F261193F9087005C8B43</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>3DCFE79F67F8DBC0305663F4</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>BUNDLE_LOADER</key>
-				<string>$(BUILT_PRODUCTS_DIR)/JPSimulatorHacksSample.app/JPSimulatorHacksSample</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(SDKROOT)/Developer/Library/Frameworks</string>
-					<string>$(inherited)</string>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-				</array>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>JPSimulatorHacksSample/JPSimulatorHacksSample-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>JPSimulatorHacksSampleTests/JPSimulatorHacksSampleTests-Info.plist</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>TEST_HOST</key>
-				<string>$(BUNDLE_LOADER)</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>xctest</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>3EF96CF1193F914500E117DC</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>3EF96CF2193F915900E117DC</string>
-				<string>3EF96CF3193F915900E117DC</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>JPSimulatorHacks</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3EF96CF2193F915900E117DC</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>JPSimulatorHacks.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3EF96CF3193F915900E117DC</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>JPSimulatorHacks.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>49F39C16C71D470F95035BC9</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-JPSimulatorHacksSampleTests.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>5334BE86380A408DBF393030</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Check Pods Manifest.lock</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
-if [[ $? != 0 ]] ; then
-    cat &lt;&lt; EOM
-error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
-EOM
-    exit 1
-fi
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>6052FE846C274F77BB137DD5</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Copy Pods Resources</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/Pods/Pods-JPSimulatorHacksSampleTests-resources.sh"
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>63BE4141C44748CCB995A770</key>
-		<dict>
-			<key>fileRef</key>
-			<string>49F39C16C71D470F95035BC9</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>679B02341965D14D00600C91</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>file.storyboard</string>
-			<key>path</key>
-			<string>Storyboard.storyboard</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>679B02351965D14D00600C91</key>
-		<dict>
-			<key>fileRef</key>
-			<string>679B02341965D14D00600C91</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>A7B164568502C22791AA0ADA</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-JPSimulatorHacksSampleTests.debug.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Pods-JPSimulatorHacksSampleTests.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-	</dict>
-	<key>rootObject</key>
-	<string>3EC4F228193F9087005C8B43</string>
-</dict>
-</plist>
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		3EC4F234193F9087005C8B43 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3EC4F233193F9087005C8B43 /* Foundation.framework */; };
+		3EC4F236193F9087005C8B43 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3EC4F235193F9087005C8B43 /* CoreGraphics.framework */; };
+		3EC4F238193F9087005C8B43 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3EC4F237193F9087005C8B43 /* UIKit.framework */; };
+		3EC4F23E193F9087005C8B43 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 3EC4F23C193F9087005C8B43 /* InfoPlist.strings */; };
+		3EC4F240193F9087005C8B43 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EC4F23F193F9087005C8B43 /* main.m */; };
+		3EC4F244193F9087005C8B43 /* JPAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EC4F243193F9087005C8B43 /* JPAppDelegate.m */; };
+		3EC4F246193F9087005C8B43 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3EC4F245193F9087005C8B43 /* Images.xcassets */; };
+		3EC4F24D193F9087005C8B43 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3EC4F24C193F9087005C8B43 /* XCTest.framework */; };
+		3EC4F24E193F9087005C8B43 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3EC4F233193F9087005C8B43 /* Foundation.framework */; };
+		3EC4F24F193F9087005C8B43 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3EC4F237193F9087005C8B43 /* UIKit.framework */; };
+		3EC4F257193F9087005C8B43 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 3EC4F255193F9087005C8B43 /* InfoPlist.strings */; };
+		3EC4F259193F9087005C8B43 /* JPSimulatorHacksSampleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EC4F258193F9087005C8B43 /* JPSimulatorHacksSampleTests.m */; };
+		63BE4141C44748CCB995A770 /* libPods-JPSimulatorHacksSampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 49F39C16C71D470F95035BC9 /* libPods-JPSimulatorHacksSampleTests.a */; };
+		679B02351965D14D00600C91 /* Storyboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 679B02341965D14D00600C91 /* Storyboard.storyboard */; };
+		8655A7E71A7505F800DCE344 /* JPSimulatorHacks_CalendarAccess_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8655A7E61A7505F800DCE344 /* JPSimulatorHacks_CalendarAccess_Tests.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		3EC4F250193F9087005C8B43 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3EC4F228193F9087005C8B43 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3EC4F22F193F9087005C8B43;
+			remoteInfo = JPSimulatorHacksSample;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		3DCFE79F67F8DBC0305663F4 /* Pods-JPSimulatorHacksSampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JPSimulatorHacksSampleTests.release.xcconfig"; path = "Pods/Pods-JPSimulatorHacksSampleTests.release.xcconfig"; sourceTree = "<group>"; };
+		3EC4F230193F9087005C8B43 /* JPSimulatorHacksSample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JPSimulatorHacksSample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		3EC4F233193F9087005C8B43 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		3EC4F235193F9087005C8B43 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		3EC4F237193F9087005C8B43 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		3EC4F23B193F9087005C8B43 /* JPSimulatorHacksSample-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "JPSimulatorHacksSample-Info.plist"; sourceTree = "<group>"; };
+		3EC4F23D193F9087005C8B43 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		3EC4F23F193F9087005C8B43 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		3EC4F241193F9087005C8B43 /* JPSimulatorHacksSample-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "JPSimulatorHacksSample-Prefix.pch"; sourceTree = "<group>"; };
+		3EC4F242193F9087005C8B43 /* JPAppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JPAppDelegate.h; sourceTree = "<group>"; };
+		3EC4F243193F9087005C8B43 /* JPAppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = JPAppDelegate.m; sourceTree = "<group>"; };
+		3EC4F245193F9087005C8B43 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		3EC4F24B193F9087005C8B43 /* JPSimulatorHacksSampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = JPSimulatorHacksSampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		3EC4F24C193F9087005C8B43 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		3EC4F254193F9087005C8B43 /* JPSimulatorHacksSampleTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "JPSimulatorHacksSampleTests-Info.plist"; sourceTree = "<group>"; };
+		3EC4F256193F9087005C8B43 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		3EC4F258193F9087005C8B43 /* JPSimulatorHacksSampleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = JPSimulatorHacksSampleTests.m; sourceTree = "<group>"; };
+		3EF96CF2193F915900E117DC /* JPSimulatorHacks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JPSimulatorHacks.h; sourceTree = "<group>"; };
+		3EF96CF3193F915900E117DC /* JPSimulatorHacks.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JPSimulatorHacks.m; sourceTree = "<group>"; };
+		49F39C16C71D470F95035BC9 /* libPods-JPSimulatorHacksSampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-JPSimulatorHacksSampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		679B02341965D14D00600C91 /* Storyboard.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Storyboard.storyboard; sourceTree = "<group>"; };
+		8655A7E61A7505F800DCE344 /* JPSimulatorHacks_CalendarAccess_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JPSimulatorHacks_CalendarAccess_Tests.m; sourceTree = "<group>"; };
+		A7B164568502C22791AA0ADA /* Pods-JPSimulatorHacksSampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JPSimulatorHacksSampleTests.debug.xcconfig"; path = "Pods/Pods-JPSimulatorHacksSampleTests.debug.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		3EC4F22D193F9087005C8B43 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3EC4F236193F9087005C8B43 /* CoreGraphics.framework in Frameworks */,
+				3EC4F238193F9087005C8B43 /* UIKit.framework in Frameworks */,
+				3EC4F234193F9087005C8B43 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3EC4F248193F9087005C8B43 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3EC4F24D193F9087005C8B43 /* XCTest.framework in Frameworks */,
+				3EC4F24F193F9087005C8B43 /* UIKit.framework in Frameworks */,
+				3EC4F24E193F9087005C8B43 /* Foundation.framework in Frameworks */,
+				63BE4141C44748CCB995A770 /* libPods-JPSimulatorHacksSampleTests.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		3EC4F227193F9087005C8B43 = {
+			isa = PBXGroup;
+			children = (
+				3EC4F232193F9087005C8B43 /* Frameworks */,
+				3EF96CF1193F914500E117DC /* JPSimulatorHacks */,
+				3EC4F239193F9087005C8B43 /* JPSimulatorHacksSample */,
+				3EC4F252193F9087005C8B43 /* JPSimulatorHacksSampleTests */,
+				3EC4F231193F9087005C8B43 /* Products */,
+				A7B164568502C22791AA0ADA /* Pods-JPSimulatorHacksSampleTests.debug.xcconfig */,
+				3DCFE79F67F8DBC0305663F4 /* Pods-JPSimulatorHacksSampleTests.release.xcconfig */,
+			);
+			sourceTree = "<group>";
+		};
+		3EC4F231193F9087005C8B43 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				3EC4F230193F9087005C8B43 /* JPSimulatorHacksSample.app */,
+				3EC4F24B193F9087005C8B43 /* JPSimulatorHacksSampleTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		3EC4F232193F9087005C8B43 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				3EC4F233193F9087005C8B43 /* Foundation.framework */,
+				3EC4F235193F9087005C8B43 /* CoreGraphics.framework */,
+				3EC4F237193F9087005C8B43 /* UIKit.framework */,
+				3EC4F24C193F9087005C8B43 /* XCTest.framework */,
+				49F39C16C71D470F95035BC9 /* libPods-JPSimulatorHacksSampleTests.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		3EC4F239193F9087005C8B43 /* JPSimulatorHacksSample */ = {
+			isa = PBXGroup;
+			children = (
+				3EC4F245193F9087005C8B43 /* Images.xcassets */,
+				3EC4F242193F9087005C8B43 /* JPAppDelegate.h */,
+				3EC4F243193F9087005C8B43 /* JPAppDelegate.m */,
+				679B02341965D14D00600C91 /* Storyboard.storyboard */,
+				3EC4F23A193F9087005C8B43 /* Supporting Files */,
+			);
+			path = JPSimulatorHacksSample;
+			sourceTree = "<group>";
+		};
+		3EC4F23A193F9087005C8B43 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				3EC4F23B193F9087005C8B43 /* JPSimulatorHacksSample-Info.plist */,
+				3EC4F23C193F9087005C8B43 /* InfoPlist.strings */,
+				3EC4F23F193F9087005C8B43 /* main.m */,
+				3EC4F241193F9087005C8B43 /* JPSimulatorHacksSample-Prefix.pch */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		3EC4F252193F9087005C8B43 /* JPSimulatorHacksSampleTests */ = {
+			isa = PBXGroup;
+			children = (
+				8655A7E61A7505F800DCE344 /* JPSimulatorHacks_CalendarAccess_Tests.m */,
+				3EC4F258193F9087005C8B43 /* JPSimulatorHacksSampleTests.m */,
+				3EC4F253193F9087005C8B43 /* Supporting Files */,
+			);
+			path = JPSimulatorHacksSampleTests;
+			sourceTree = "<group>";
+		};
+		3EC4F253193F9087005C8B43 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				3EC4F254193F9087005C8B43 /* JPSimulatorHacksSampleTests-Info.plist */,
+				3EC4F255193F9087005C8B43 /* InfoPlist.strings */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		3EF96CF1193F914500E117DC /* JPSimulatorHacks */ = {
+			isa = PBXGroup;
+			children = (
+				3EF96CF2193F915900E117DC /* JPSimulatorHacks.h */,
+				3EF96CF3193F915900E117DC /* JPSimulatorHacks.m */,
+			);
+			path = JPSimulatorHacks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		3EC4F22F193F9087005C8B43 /* JPSimulatorHacksSample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3EC4F25C193F9087005C8B43 /* Build configuration list for PBXNativeTarget "JPSimulatorHacksSample" */;
+			buildPhases = (
+				3EC4F22C193F9087005C8B43 /* Sources */,
+				3EC4F22D193F9087005C8B43 /* Frameworks */,
+				3EC4F22E193F9087005C8B43 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = JPSimulatorHacksSample;
+			productName = JPSimulatorHacksSample;
+			productReference = 3EC4F230193F9087005C8B43 /* JPSimulatorHacksSample.app */;
+			productType = "com.apple.product-type.application";
+		};
+		3EC4F24A193F9087005C8B43 /* JPSimulatorHacksSampleTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3EC4F25F193F9087005C8B43 /* Build configuration list for PBXNativeTarget "JPSimulatorHacksSampleTests" */;
+			buildPhases = (
+				5334BE86380A408DBF393030 /* Check Pods Manifest.lock */,
+				3EC4F247193F9087005C8B43 /* Sources */,
+				3EC4F248193F9087005C8B43 /* Frameworks */,
+				3EC4F249193F9087005C8B43 /* Resources */,
+				6052FE846C274F77BB137DD5 /* Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3EC4F251193F9087005C8B43 /* PBXTargetDependency */,
+			);
+			name = JPSimulatorHacksSampleTests;
+			productName = JPSimulatorHacksSampleTests;
+			productReference = 3EC4F24B193F9087005C8B43 /* JPSimulatorHacksSampleTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		3EC4F228193F9087005C8B43 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				CLASSPREFIX = JP;
+				LastUpgradeCheck = 0510;
+				TargetAttributes = {
+					3EC4F24A193F9087005C8B43 = {
+						TestTargetID = 3EC4F22F193F9087005C8B43;
+					};
+				};
+			};
+			buildConfigurationList = 3EC4F22B193F9087005C8B43 /* Build configuration list for PBXProject "JPSimulatorHacksSample" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 3EC4F227193F9087005C8B43;
+			productRefGroup = 3EC4F231193F9087005C8B43 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				3EC4F22F193F9087005C8B43 /* JPSimulatorHacksSample */,
+				3EC4F24A193F9087005C8B43 /* JPSimulatorHacksSampleTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		3EC4F22E193F9087005C8B43 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3EC4F23E193F9087005C8B43 /* InfoPlist.strings in Resources */,
+				3EC4F246193F9087005C8B43 /* Images.xcassets in Resources */,
+				679B02351965D14D00600C91 /* Storyboard.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3EC4F249193F9087005C8B43 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3EC4F257193F9087005C8B43 /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		5334BE86380A408DBF393030 /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		6052FE846C274F77BB137DD5 /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Pods-JPSimulatorHacksSampleTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		3EC4F22C193F9087005C8B43 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3EC4F244193F9087005C8B43 /* JPAppDelegate.m in Sources */,
+				3EC4F240193F9087005C8B43 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3EC4F247193F9087005C8B43 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3EC4F259193F9087005C8B43 /* JPSimulatorHacksSampleTests.m in Sources */,
+				8655A7E71A7505F800DCE344 /* JPSimulatorHacks_CalendarAccess_Tests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		3EC4F251193F9087005C8B43 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3EC4F22F193F9087005C8B43 /* JPSimulatorHacksSample */;
+			targetProxy = 3EC4F250193F9087005C8B43 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		3EC4F23C193F9087005C8B43 /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				3EC4F23D193F9087005C8B43 /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		3EC4F255193F9087005C8B43 /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				3EC4F256193F9087005C8B43 /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		3EC4F25A193F9087005C8B43 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		3EC4F25B193F9087005C8B43 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		3EC4F25D193F9087005C8B43 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "JPSimulatorHacksSample/JPSimulatorHacksSample-Prefix.pch";
+				INFOPLIST_FILE = "JPSimulatorHacksSample/JPSimulatorHacksSample-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = app;
+			};
+			name = Debug;
+		};
+		3EC4F25E193F9087005C8B43 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "JPSimulatorHacksSample/JPSimulatorHacksSample-Prefix.pch";
+				INFOPLIST_FILE = "JPSimulatorHacksSample/JPSimulatorHacksSample-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = app;
+			};
+			name = Release;
+		};
+		3EC4F260193F9087005C8B43 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A7B164568502C22791AA0ADA /* Pods-JPSimulatorHacksSampleTests.debug.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/JPSimulatorHacksSample.app/JPSimulatorHacksSample";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "JPSimulatorHacksSample/JPSimulatorHacksSample-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = "JPSimulatorHacksSampleTests/JPSimulatorHacksSampleTests-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUNDLE_LOADER)";
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Debug;
+		};
+		3EC4F261193F9087005C8B43 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3DCFE79F67F8DBC0305663F4 /* Pods-JPSimulatorHacksSampleTests.release.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/JPSimulatorHacksSample.app/JPSimulatorHacksSample";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "JPSimulatorHacksSample/JPSimulatorHacksSample-Prefix.pch";
+				INFOPLIST_FILE = "JPSimulatorHacksSampleTests/JPSimulatorHacksSampleTests-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUNDLE_LOADER)";
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		3EC4F22B193F9087005C8B43 /* Build configuration list for PBXProject "JPSimulatorHacksSample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3EC4F25A193F9087005C8B43 /* Debug */,
+				3EC4F25B193F9087005C8B43 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3EC4F25C193F9087005C8B43 /* Build configuration list for PBXNativeTarget "JPSimulatorHacksSample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3EC4F25D193F9087005C8B43 /* Debug */,
+				3EC4F25E193F9087005C8B43 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3EC4F25F193F9087005C8B43 /* Build configuration list for PBXNativeTarget "JPSimulatorHacksSampleTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3EC4F260193F9087005C8B43 /* Debug */,
+				3EC4F261193F9087005C8B43 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 3EC4F228193F9087005C8B43 /* Project object */;
+}

--- a/JPSimulatorHacksSampleTests/JPSimulatorHacks_CalendarAccess_Tests.m
+++ b/JPSimulatorHacksSampleTests/JPSimulatorHacks_CalendarAccess_Tests.m
@@ -1,6 +1,6 @@
 //
-//  JPSimulatorHacks.h
-//  JPSimulatorHacks
+//  JPSimulatorHacks_CalendarAccess_Tests.m
+//  JPSimulatorHacksSample
 //
 //  Created by Johannes Plunien on 04/06/14.
 //  Copyright (C) 2014 Johannes Plunien
@@ -24,30 +24,28 @@
 //  THE SOFTWARE.
 //
 
-#import <Foundation/Foundation.h>
+#define EXP_SHORTHAND
 
-@class ALAsset;
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+#import <Expecta/Expecta.h>
 
-@interface JPSimulatorHacks : NSObject
+#import <EventKit/EventKit.h>
 
-// This is blocking, on purpose!
-+ (ALAsset *)addAssetWithURL:(NSURL *)imageURL;
+#import <JPSimulatorHacks/JPSimulatorHacks.h>
 
-+ (void)editGlobalPreferences:(void (^)(NSMutableDictionary *preferences))block;
-+ (void)editPreferences:(void (^)(NSMutableDictionary *preferences))block;
+@interface JPSimulatorHacks_CalendarAccess_Tests : XCTestCase
+@end
 
-+ (BOOL)grantAccessToAddressBook;
-+ (BOOL)grantAccessToAddressBookForBundleIdentifier:(NSString *)bundleIdentifier;
+@implementation JPSimulatorHacks_CalendarAccess_Tests
 
-+ (BOOL)grantAccessToPhotos;
-+ (BOOL)grantAccessToPhotosForBundleIdentifier:(NSString *)bundleIdentifier;
+- (void)testGrantingAccessToCalendar {
+    EKAuthorizationStatus authorizationStatus;
 
-+ (BOOL)grantAccessToCalendar;
-+ (BOOL)grantAccessToCalendarForBundleIdentifier:(NSString *)bundleIdentifier;
+    [JPSimulatorHacks grantAccessToCalendar];
 
-+ (void)setTimeout:(NSTimeInterval)timeout;
-
-+ (void)disableKeyboardHelpers;
-+ (void)setDefaultKeyboard:(NSString *)keyboard;
+    authorizationStatus = [EKEventStore authorizationStatusForEntityType:EKEntityTypeEvent];
+    expect(authorizationStatus).to.equal(EKAuthorizationStatusAuthorized);
+}
 
 @end

--- a/README.md
+++ b/README.md
@@ -4,13 +4,9 @@
 
 ## Description
 
-Hack the Simulator in your tests (grant access to photos, contacts, ...).
+Hack the Simulator in your tests (grant access to photos, contacts, calendar ...).
 
-Did you ever have the problem that your code was wrapping the `AddressBook` or
-the `ALAssetsLibrary` APIs? Running tests can be annoying then. There's this
-`UIAlertView` asking the user to grant access to the contacts and photos,
-which blocks and breaks your tests. Using `JPSimulatorHacks` you can easily
-grant this access before running your tests.
+Did you ever have the problem that your code was wrapping the `AddressBook`, the `EventKit` or the `ALAssetsLibrary` APIs? Running tests can be annoying then. There's this `UIAlertView` asking the user to grant access to the contacts and photos, which blocks and breaks your tests. Using `JPSimulatorHacks` you can easily grant this access before running your tests.
 
 ## Usage
 
@@ -88,6 +84,29 @@ the Asset is available.
 [JPSimulatorHacks grantAccessToPhotos];
 NSURL *assetURL = [NSURL URLWithString:@"https://raw.githubusercontent.com/plu/JPSimulatorHacks/master/Data/test.png"];
 ALAsset *asset = [JPSimulatorHacks addAssetWithURL:assetURL];
+```
+
+### Calendar
+
+```objc
+#import <JPSimulatorHacks/JPSimulatorHacks.h>
+
+@implementation MyAppTests
+
++ (void)setUp
+{
+    [super setUp];
+    [JPSimulatorHacks grantAccessToCalendar];
+}
+
+@end
+```
+
+This will grant access to the calendar for the current bundle identifier.
+There's also an API to specify the bundle identifier, if necessary:
+
+```objc
++ (BOOL)grantAccessToCalendadrForBundleIdentifier:(NSString *)bundleIdentifier;
 ```
 
 ### Timeout


### PR DESCRIPTION
Hello, @plu !

JPSimulatorHacks is very helpful! I found it accidentally (before that I had not known such project existed before). Now I am able to test my calendar syncs code without exhaustive stubbing of EKEventStore and friends.

I think my PR is self-explanatory. Just two minor notes:

1) This long diff in project.pbxproj is made by Xcode - I just added one test file. I believe it is just some Xcode version upgrade related.

2) [_I am not sure if this also applies to AddressBook and Assets Library_] Initially I planned to include methods I've added: `denyAccessToCalendar` (explicitly sets authorization status to EKAuthorizationStatusDenied) and `resetCalendarAccessTable` (explicitly sets to EKAuthorizationStatusNotDetermined) but I found that while these methods worked correctly according to `Settings/Privacy` (I did look up them manually by hands) for some reasons method `+[EKEventStore authorizationStatusForEntityType:]` didn't follow these changes correctly. Looks like when it is fired the first time it scans `TCC.db` and caches its value, then even if I change `TCC.db` correctly (visiting Settings/Privacy confirms that) I still see previous result of authorization status. What this means is that currently within my unit tests I am only able to have `EKAuthorizationStatusAuthorized` i.e. I am not able to do things like:

```
- (void)testGrantingAccessToCalendar {
    EKAuthorizationStatus authorizationStatus;

    [JPSimulatorHacks denyAccessToCalendar];

    authorizationStatus = [EKEventStore authorizationStatusForEntityType:EKEntityTypeEvent];
    expect(authorizationStatus).to.equal(EKAuthorizationStatusDenied); // This will work!

    [JPSimulatorHacks grantAccessToCalendar];

    authorizationStatus = [EKEventStore authorizationStatusForEntityType:EKEntityTypeEvent];
    expect(authorizationStatus).to.equal(EKAuthorizationStatusAuthorized); // This WILL NOT work! Because authorizationStatus will still be at previous EKAuthorizationStatusDenied state
}
```

while this will work and actually constitutes this PR:

```
- (void)testGrantingAccessToCalendar {
    EKAuthorizationStatus authorizationStatus;

    [JPSimulatorHacks grantAccessToCalendar];

    authorizationStatus = [EKEventStore authorizationStatusForEntityType:EKEntityTypeEvent];
    expect(authorizationStatus).to.equal(EKAuthorizationStatusAuthorized); // This value is read from TCC.db and will be cached by EKEventStore so that all EK-classes become available for the whole unit test suite
}
```
----

Thanks for this project! 
