### PR TITLE
Add CocoaPods frameworks support

### DIFF
--- a/JPSimulatorHacks/JPSimulatorHacksDB.m
+++ b/JPSimulatorHacks/JPSimulatorHacksDB.m
@@ -28,7 +28,7 @@
 #if defined(JPSH_SQLITE_STANDALONE)
 #import <sqlite3/sqlite3.h>
 #else
-#import "sqlite3.h"
+#import <sqlite3.h>
 #endif
 
 @interface JPSimulatorHacksDB () {


### PR DESCRIPTION
The sqlite3.h must be imported as a system header to be able to use
use_framework with CocoaPods.